### PR TITLE
feat(nightshift): add `elastic nightshift ask` command (POC) with agent-friendly output

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,37 @@ elastic cloud serverless cross-project get-elasticsearch-project-link-candidates
 
 Run `elastic cloud serverless --help` for all available groups.
 
+### `nightshift` - Nightshift Investigation Agent ⚠️ Experimental / POC
+
+Ask the [Nightshift investigation agent](https://www.elastic.co/guide/en/observability/current/nightshift.html)
+a question from the terminal. Requires a Kibana service block in the active context and an
+Enterprise license.
+
+```bash
+# First turn — starts a new conversation; the conversation id appears on stderr
+elastic nightshift ask "what significant events fired in the last hour?"
+
+# Continue an existing conversation
+elastic nightshift ask --conversation-id <uuid> "which service caused it?"
+
+# JSON output — emits { conversation_id, response }; safe to pipe
+elastic nightshift ask --json "why is checkout slow?" | jq '.response'
+```
+
+The command calls the agent builder converse endpoint (hardcoded to
+`significant-events.investigation`) and prints only the prose answer. The `conversation:`
+hint on stderr can be suppressed by redirecting stderr:
+
+```bash
+elastic nightshift ask "…" 2>/dev/null
+```
+
+Currently speaks to the agent builder `POST /api/agent_builder/converse` endpoint directly.
+A purpose-built `POST /api/nightshift/ask` will replace this once it lands server-side.
+
+> **Note:** This is an early POC. Output format and flags may change without notice.
+> Pass `--accept-experimental` to suppress the stability warning.
+
 ## Extensions
 
 Extensions add new top-level subcommands to the CLI. Once installed, an extension named `demo` is invoked as `elastic demo`.

--- a/README.md
+++ b/README.md
@@ -491,8 +491,8 @@ elastic nightshift ask --verbose "why is checkout slow?"
 ```
 
 The command calls the agent builder converse endpoint (hardcoded to
-`significant-events.investigation`) and prints only the prose answer. When stdout is a TTY,
-the `conversation:` hint on stderr can be suppressed by redirecting stderr:
+`significant-events.investigation`) and prints only the prose answer. The `conversation:`
+hint on stderr can be suppressed by redirecting stderr:
 
 ```bash
 elastic nightshift ask "…" 2>/dev/null

--- a/README.md
+++ b/README.md
@@ -477,13 +477,22 @@ elastic nightshift ask "what significant events fired in the last hour?"
 # Continue an existing conversation
 elastic nightshift ask --conversation-id <uuid> "which service caused it?"
 
-# JSON output — emits { conversation_id, response }; safe to pipe
-elastic nightshift ask --json "why is checkout slow?" | jq '.response'
+# JSON output — emits { conversation_id, message[, tool_calls] }; safe to pipe
+elastic nightshift ask --json "why is checkout slow?" | jq '.message'
+
+# Piped stdout (non-TTY) auto-switches to JSON without --json
+elastic nightshift ask "why is checkout slow?" | jq '.message'
+
+# Set a timeout (abort after 60 seconds)
+elastic nightshift ask --timeout 60 "why is checkout slow?"
+
+# Show tool call count in text mode
+elastic nightshift ask --verbose "why is checkout slow?"
 ```
 
 The command calls the agent builder converse endpoint (hardcoded to
-`significant-events.investigation`) and prints only the prose answer. The `conversation:`
-hint on stderr can be suppressed by redirecting stderr:
+`significant-events.investigation`) and prints only the prose answer. When stdout is a TTY,
+the `conversation:` hint on stderr can be suppressed by redirecting stderr:
 
 ```bash
 elastic nightshift ask "…" 2>/dev/null

--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -104790,6 +104790,20 @@
         },
         {
           "role": "flag",
+          "name": "timeout",
+          "type": "string",
+          "required": false,
+          "summary": "Abort the request after this many seconds (default: no timeout)"
+        },
+        {
+          "role": "flag",
+          "name": "verbose",
+          "type": "boolean",
+          "required": false,
+          "summary": "Show agent tool call count after the answer"
+        },
+        {
+          "role": "flag",
           "name": "prompt",
           "type": "string",
           "required": false,

--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -104783,13 +104783,6 @@
       "options": [
         {
           "role": "flag",
-          "name": "accept-experimental",
-          "type": "boolean",
-          "required": false,
-          "summary": "Acknowledge that this command is experimental and may be removed; suppresses the warning"
-        },
-        {
-          "role": "flag",
           "name": "timeout",
           "type": "string",
           "required": false,

--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -9905,7 +9905,7 @@
                       "name": "active-only",
                       "type": "boolean",
                       "required": false,
-                      "summary": "If `true`, the response only includes shard recoveries that have not yet completed (excludes `done` stage)."
+                      "summary": "If `true`, the response only includes ongoing shard recoveries."
                     },
                     {
                       "role": "flag",
@@ -26666,7 +26666,7 @@
                       "name": "active-only",
                       "type": "boolean",
                       "required": false,
-                      "summary": "If `true`, the response only includes shard recoveries that have not yet completed (excludes `DONE` stage)."
+                      "summary": "If `true`, the response only includes ongoing shard recoveries."
                     },
                     {
                       "role": "flag",
@@ -52200,7 +52200,7 @@
                       "name": "wait-for-completion",
                       "type": "boolean",
                       "required": false,
-                      "summary": "If `false`, the request returns a response as soon as the deletes are scheduled.\nIf `true`, the request returns a response when the matching snapshots are all deleted, and the post-deletion cleanup work associated with the request has completed.\nIf you make several requests to the delete-snapshots API targetting overlapping collections of snapshots then some of those requests may perform different parts of the associated post-deletion cleanup work, returning their responses at different times.\nFor example, if you make two requests to delete the same snapshot then sometimes all of the post-deletion cleanup work will be associated with the first request, delaying its response, while the second request has no associated post-deletion cleanup work and receives its response as soon as the snapshot has been deleted."
+                      "summary": "If `true`, the request returns a response when the matching snapshots are all deleted.\nIf `false`, the request returns a response as soon as the deletes are scheduled."
                     },
                     {
                       "role": "flag",
@@ -58664,38 +58664,6 @@
                     },
                     {
                       "role": "flag",
-                      "name": "page",
-                      "type": "number",
-                      "required": false,
-                      "summary": "Page number, 1-based."
-                    },
-                    {
-                      "role": "flag",
-                      "name": "per-page",
-                      "type": "number",
-                      "required": false,
-                      "summary": "Number of results per page. Maximum 1000."
-                    },
-                    {
-                      "role": "flag",
-                      "name": "sort-order",
-                      "type": "enum",
-                      "required": false,
-                      "summary": "Sort direction for results, ordered by updated_at.",
-                      "enumValues": [
-                        "asc",
-                        "desc"
-                      ]
-                    },
-                    {
-                      "role": "flag",
-                      "name": "pinned",
-                      "type": "boolean",
-                      "required": false,
-                      "summary": "Filter to pinned (true) or unpinned (false) conversations. Omit to return all."
-                    },
-                    {
-                      "role": "flag",
                       "name": "input-file",
                       "type": "string",
                       "required": false,
@@ -60200,13 +60168,6 @@
                   ],
                   "name": "post-agent-builder-tools-execute",
                   "parameters": [
-                    {
-                      "role": "flag",
-                      "name": "approvals",
-                      "type": "string",
-                      "required": false,
-                      "summary": "Actions the tool run may take that would otherwise need a live user to approve them. Applies to this run and any sub-agents it spawns."
-                    },
                     {
                       "role": "flag",
                       "name": "connector-id",
@@ -64817,7 +64778,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "delete-case",
+                  "name": "delete-case-default-space",
                   "parameters": [
                     {
                       "role": "dryRun",
@@ -64848,7 +64809,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "update-case",
+                  "name": "update-case-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -64884,7 +64845,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "create-case",
+                  "name": "create-case-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -64918,12 +64879,6 @@
                       "name": "description",
                       "type": "string",
                       "required": true
-                    },
-                    {
-                      "role": "flag",
-                      "name": "extended-fields",
-                      "type": "string",
-                      "required": false
                     },
                     {
                       "role": "flag",
@@ -65001,7 +64956,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "find-cases",
+                  "name": "find-cases-default-space",
                   "parameters": [
                     {
                       "role": "dryRun",
@@ -65025,7 +64980,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case",
+                  "name": "get-case-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65063,7 +65018,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-alerts",
+                  "name": "get-case-alerts-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65101,7 +65056,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "delete-case-comments",
+                  "name": "delete-case-comments-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65146,7 +65101,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "update-case-comment",
+                  "name": "update-case-comment-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65187,7 +65142,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "add-case-comment",
+                  "name": "add-case-comment-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65228,7 +65183,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "find-case-comments",
+                  "name": "find-case-comments-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65291,7 +65246,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "delete-case-comment",
+                  "name": "delete-case-comment-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65343,7 +65298,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-comment",
+                  "name": "get-case-comment-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65388,7 +65343,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "push-case",
+                  "name": "push-case-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65436,7 +65391,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-applicable-fields",
+                  "name": "get-case-applicable-fields-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65474,7 +65429,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "add-case-file",
+                  "name": "add-case-file-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65523,7 +65478,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "find-case-activity",
+                  "name": "find-case-activity-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65594,7 +65549,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-cases-by-alert",
+                  "name": "get-cases-by-alert-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65640,7 +65595,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-configuration",
+                  "name": "get-case-configuration-default-space",
                   "parameters": [
                     {
                       "role": "dryRun",
@@ -65664,7 +65619,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "set-case-configuration",
+                  "name": "set-case-configuration-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65735,7 +65690,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "update-case-configuration",
+                  "name": "update-case-configuration-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65809,7 +65764,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "find-case-connectors",
+                  "name": "find-case-connectors-default-space",
                   "parameters": [
                     {
                       "role": "dryRun",
@@ -65833,7 +65788,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-applicable-fields",
+                  "name": "get-applicable-fields-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -65878,7 +65833,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-reporters",
+                  "name": "get-case-reporters-default-space",
                   "parameters": [
                     {
                       "role": "dryRun",
@@ -65902,7 +65857,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-tags",
+                  "name": "get-case-tags-default-space",
                   "parameters": [
                     {
                       "role": "dryRun",
@@ -65926,7 +65881,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-templates",
+                  "name": "get-case-templates-default-space",
                   "parameters": [
                     {
                       "role": "dryRun",
@@ -65950,7 +65905,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "create-case-template",
+                  "name": "create-case-template-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -66025,7 +65980,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "delete-case-template",
+                  "name": "delete-case-template-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -66070,7 +66025,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "get-case-template",
+                  "name": "get-case-template-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -66115,7 +66070,7 @@
                     "kb",
                     "cases"
                   ],
-                  "name": "update-case-template",
+                  "name": "update-case-template-default-space",
                   "parameters": [
                     {
                       "role": "flag",
@@ -66827,51 +66782,6 @@
                     }
                   ],
                   "summary": "Get data streams",
-                  "intent": {
-                    "destructive": false,
-                    "idempotent": true,
-                    "scope": "global",
-                    "requiresAuth": true
-                  }
-                },
-                {
-                  "path": [
-                    "stack",
-                    "kb",
-                    "data-streams"
-                  ],
-                  "name": "get-fleet-data-streams-data",
-                  "parameters": [
-                    {
-                      "role": "flag",
-                      "name": "data-streams",
-                      "type": "string",
-                      "required": true,
-                      "summary": "A comma-separated list of data stream index patterns to check. Each pattern must be of the form `logs-<dataset>-*` or `metrics-<dataset>-*`."
-                    },
-                    {
-                      "role": "flag",
-                      "name": "start",
-                      "type": "string",
-                      "required": true,
-                      "summary": "An ISO 8601 timestamp. Only documents with an `@timestamp` at or after this time are considered."
-                    },
-                    {
-                      "role": "flag",
-                      "name": "input-file",
-                      "type": "string",
-                      "required": false,
-                      "summary": "path to a JSON file to use as command input"
-                    },
-                    {
-                      "role": "dryRun",
-                      "name": "dry-run",
-                      "type": "boolean",
-                      "required": false,
-                      "summary": "validate all inputs and exit without performing any action"
-                    }
-                  ],
-                  "summary": "Check if data streams have data",
                   "intent": {
                     "destructive": false,
                     "idempotent": true,
@@ -74653,7 +74563,7 @@
                       "role": "flag",
                       "name": "hosts",
                       "type": "array",
-                      "required": false,
+                      "required": true,
                       "repeatable": true,
                       "elementType": "string"
                     },
@@ -74749,7 +74659,7 @@
                       "type": "enum",
                       "required": true,
                       "enumValues": [
-                        "otlp"
+                        "kafka"
                       ]
                     },
                     {
@@ -74926,12 +74836,6 @@
                     {
                       "role": "flag",
                       "name": "version",
-                      "type": "string",
-                      "required": false
-                    },
-                    {
-                      "role": "flag",
-                      "name": "otlp-exporter",
                       "type": "string",
                       "required": false
                     },
@@ -75179,7 +75083,7 @@
                       "type": "enum",
                       "required": false,
                       "enumValues": [
-                        "otlp"
+                        "kafka"
                       ]
                     },
                     {
@@ -75356,12 +75260,6 @@
                     {
                       "role": "flag",
                       "name": "version",
-                      "type": "string",
-                      "required": false
-                    },
-                    {
-                      "role": "flag",
-                      "name": "otlp-exporter",
                       "type": "string",
                       "required": false
                     },
@@ -85682,9 +85580,6 @@
                   ],
                   "summary": "Configure the Risk Engine Saved Object",
                   "intent": {
-                    "destructive": false,
-                    "idempotent": true,
-                    "scope": "global",
                     "requiresAuth": true
                   }
                 },
@@ -104433,13 +104328,6 @@
                     },
                     {
                       "role": "flag",
-                      "name": "organization-id",
-                      "type": "string",
-                      "required": true,
-                      "summary": "The Organization ID to scope the request to."
-                    },
-                    {
-                      "role": "flag",
                       "name": "input-file",
                       "type": "string",
                       "required": false,
@@ -104467,13 +104355,6 @@
                   ],
                   "name": "create-traffic-filter",
                   "parameters": [
-                    {
-                      "role": "flag",
-                      "name": "organization-id",
-                      "type": "string",
-                      "required": true,
-                      "summary": "The Organization ID to scope the request to."
-                    },
                     {
                       "role": "flag",
                       "name": "name",
@@ -104568,13 +104449,6 @@
                     },
                     {
                       "role": "flag",
-                      "name": "organization-id",
-                      "type": "string",
-                      "required": true,
-                      "summary": "The Organization ID to scope the request to."
-                    },
-                    {
-                      "role": "flag",
                       "name": "input-file",
                       "type": "string",
                       "required": false,
@@ -104608,13 +104482,6 @@
                       "type": "string",
                       "required": true,
                       "summary": "The traffic filter ID."
-                    },
-                    {
-                      "role": "flag",
-                      "name": "organization-id",
-                      "type": "string",
-                      "required": true,
-                      "summary": "The Organization ID to scope the request to."
                     },
                     {
                       "role": "flag",
@@ -104880,6 +104747,67 @@
       "namespaces": [],
       "summary": "Search, read, and ask questions about Elastic documentation",
       "options": [
+        {
+          "role": "flag",
+          "name": "input-file",
+          "type": "string",
+          "required": false,
+          "summary": "path to a JSON file to use as command input"
+        },
+        {
+          "role": "dryRun",
+          "name": "dry-run",
+          "type": "boolean",
+          "required": false,
+          "summary": "validate all inputs and exit without performing any action"
+        }
+      ]
+    },
+    {
+      "segment": "nightshift",
+      "commands": [
+        {
+          "path": [
+            "nightshift"
+          ],
+          "name": "ask",
+          "parameters": [],
+          "summary": "Ask the Nightshift investigation agent a question (single answer)",
+          "intent": {
+            "requiresAuth": true
+          }
+        }
+      ],
+      "namespaces": [],
+      "summary": "Ask the Nightshift investigation agent",
+      "options": [
+        {
+          "role": "flag",
+          "name": "accept-experimental",
+          "type": "boolean",
+          "required": false,
+          "summary": "Acknowledge that this command is experimental and may be removed; suppresses the warning"
+        },
+        {
+          "role": "flag",
+          "name": "prompt",
+          "type": "string",
+          "required": false,
+          "summary": "Question or instruction for the Nightshift investigation agent"
+        },
+        {
+          "role": "flag",
+          "name": "conversation-id",
+          "type": "string",
+          "required": false,
+          "summary": "Continue an existing conversation instead of starting a new one",
+          "validations": [
+            {
+              "kind": "regex",
+              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            }
+          ]
+        },
         {
           "role": "flag",
           "name": "input-file",

--- a/scripts/create-dist-package-jsons.mjs
+++ b/scripts/create-dist-package-jsons.mjs
@@ -24,6 +24,7 @@ const dirs = [
   'dist/extension',
   'dist/kb',
   'dist/lib',
+  'dist/nightshift',
   'dist/sanitize',
   'dist/status',
 ]

--- a/src/completion/complete.ts
+++ b/src/completion/complete.ts
@@ -199,6 +199,14 @@ export async function buildCompletionTree (rewrittenWords: readonly string[]): P
     root.addCommand(defineGroup({ name: 'docs', description: 'Search, read, and ask questions about Elastic documentation' }))
   }
 
+  // `nightshift` — deep-load on exact match, stub otherwise.
+  if (firstWord === 'nightshift') {
+    const { registerNightshiftCommands } = await import('../nightshift/register.ts')
+    root.addCommand(registerNightshiftCommands())
+  } else {
+    root.addCommand(defineGroup({ name: 'nightshift', description: 'Ask the Nightshift investigation agent' }))
+  }
+
   // `config` — deep-load on exact match, stub otherwise.
   if (firstWord === 'config') {
     const { registerConfigCommands } = await import('../config/commands.ts')

--- a/src/lib/kibana-client.ts
+++ b/src/lib/kibana-client.ts
@@ -28,6 +28,8 @@ export interface KibanaRequestParams {
   body?: unknown
   /** When set, the request is sent as multipart/form-data. Keys map to form field names; string values that resolve to an existing file path are sent as file uploads. */
   multipartFields?: Record<string, string>
+  /** AbortSignal for request cancellation (e.g. timeout). */
+  signal?: AbortSignal
 }
 
 /** A decoded Server-Sent Event: the raw `data` value is JSON-parsed when possible. */
@@ -178,6 +180,7 @@ export class KibanaClient {
     // Authorization header on cross-origin redirects, and the same-origin check below rejects any
     // response that ended up on a different origin rather than trusting it.
     const init: RequestInit = { method, headers, redirect: 'follow' }
+    if (params.signal != null) init.signal = params.signal
 
     if (params.multipartFields != null) {
       // Send as multipart/form-data; do NOT set Content-Type manually (fetch sets it with the boundary)

--- a/src/namespaces.ts
+++ b/src/namespaces.ts
@@ -123,6 +123,14 @@ export const NAMESPACES: NamespaceEntry[] = [
     },
   },
   {
+    name: 'nightshift',
+    description: 'Ask the Nightshift investigation agent',
+    load: async () => {
+      const { registerNightshiftCommands } = await import('./nightshift/register.ts')
+      return registerNightshiftCommands()
+    },
+  },
+  {
     name: 'config',
     description: 'Author and maintain the elastic config file',
     requiresContext: false,

--- a/src/nightshift/ask.ts
+++ b/src/nightshift/ask.ts
@@ -49,8 +49,8 @@ function experimentalBanner (isTTY: boolean): string {
  * Creates the `nightshift ask` command.
  *
  * Sends a prompt to the Nightshift investigation agent via the agent builder
- * converse endpoint and writes the prose answer to stdout. With `--json`,
- * emits `{ conversation_id, response }` instead.
+ * converse endpoint and writes the prose answer to stdout. With `--json` (or
+ * when stdout is not a TTY), emits `{ conversation_id, message }` instead.
  *
  * The `deps` parameter is a test seam — production callers omit it.
  */
@@ -66,30 +66,63 @@ export function createAskCommand (deps: AskDeps = defaultDeps): OpaqueCommandHan
         type: 'boolean',
         description: 'Acknowledge that this command is experimental and may be removed; suppresses the warning',
       },
+      {
+        long: 'timeout',
+        type: 'string',
+        description: 'Abort the request after this many seconds (default: no timeout)',
+      },
+      {
+        long: 'verbose',
+        type: 'boolean',
+        description: 'Show agent tool call count after the answer',
+      },
     ],
     handler: async (parsed): Promise<JsonValue> => {
       const inp = parsed.input as { prompt?: string; conversation_id?: string } | undefined
       const prompt = (parsed.arg ?? inp?.prompt ?? '').trim()
       if (prompt === '') return { error: { code: 'missing_input', message: 'prompt is required' } }
 
-      if (parsed.options['accept-experimental'] !== true && parsed.options['json'] !== true) {
+      // Auto-JSON when stdout is not a TTY so piped output is always machine-parseable.
+      const useJson = parsed.options['json'] === true || process.stdout.isTTY !== true
+
+      if (parsed.options['accept-experimental'] !== true && !useJson) {
         deps.stderr.write(experimentalBanner(process.stderr.isTTY === true))
       }
 
       const conversationId = inp?.conversation_id
-      const interactive = process.stderr.isTTY === true && parsed.options['json'] !== true
+      const interactive = process.stderr.isTTY === true && !useJson
       const spinner = interactive ? startSpinner(deps.stderr, 'Thinking…') : undefined
 
+      const rawTimeout = parsed.options['timeout']
+      const timeoutSeconds = typeof rawTimeout === 'string' && rawTimeout.length > 0
+        ? Number(rawTimeout)
+        : undefined
+
       try {
-        const answer = await deps.converse(prompt, conversationId)
+        const answer = await deps.converse(prompt, conversationId, timeoutSeconds)
         spinner?.stop()
 
-        if (parsed.options['json'] === true) {
-          return { conversation_id: answer.conversationId, response: answer.message }
+        if (useJson) {
+          const result: Record<string, unknown> = {
+            conversation_id: answer.conversationId,
+            message: answer.message,
+          }
+          if (answer.steps !== undefined) result['tool_calls'] = answer.steps
+
+          if (parsed.options['json'] === true) {
+            // Let the factory serialize and write JSON (it uses process.stdout.write directly).
+            return result as JsonValue
+          }
+          // Non-TTY auto-JSON: write ourselves so the factory doesn't swallow it.
+          deps.stdout.write(JSON.stringify(result) + '\n')
+          return null
         }
 
         const text = answer.message.endsWith('\n') ? answer.message : answer.message + '\n'
         deps.stdout.write(text)
+        if (parsed.options['verbose'] === true && answer.steps !== undefined) {
+          deps.stderr.write(`(${answer.steps} tool calls)\n`)
+        }
         deps.stderr.write(`conversation: ${answer.conversationId}\n`)
         return null
       } catch (err) {

--- a/src/nightshift/ask.ts
+++ b/src/nightshift/ask.ts
@@ -107,7 +107,9 @@ export function createAskCommand (deps: AskDeps = defaultDeps): OpaqueCommandHan
         if (parsed.options['verbose'] === true && answer.steps !== undefined) {
           deps.stderr.write(`(${answer.steps} tool calls)\n`)
         }
-        deps.stderr.write(`conversation: ${answer.conversationId}\n`)
+        if (conversationId === undefined) {
+          deps.stderr.write(`conversation: ${answer.conversationId}\n`)
+        }
         return null
       } catch (err) {
         spinner?.stop()

--- a/src/nightshift/ask.ts
+++ b/src/nightshift/ask.ts
@@ -38,13 +38,6 @@ const inputSchema: Record<string, unknown> = {
   },
 }
 
-function experimentalBanner (isTTY: boolean): string {
-  const text =
-    'Warning: "nightshift ask" is experimental and in active development.\n' +
-    '         Not yet suited for scripts or automation. Pass --accept-experimental to suppress this warning.\n\n'
-  return isTTY ? `\x1b[33m${text}\x1b[0m` : text
-}
-
 /**
  * Creates the `nightshift ask` command.
  *
@@ -61,11 +54,6 @@ export function createAskCommand (deps: AskDeps = defaultDeps): OpaqueCommandHan
     input: inputSchema,
     positionalArg: { name: 'prompt', description: 'Question or instruction', required: false },
     options: [
-      {
-        long: 'accept-experimental',
-        type: 'boolean',
-        description: 'Acknowledge that this command is experimental and may be removed; suppresses the warning',
-      },
       {
         long: 'timeout',
         type: 'string',
@@ -84,10 +72,6 @@ export function createAskCommand (deps: AskDeps = defaultDeps): OpaqueCommandHan
 
       // Auto-JSON when stdout is not a TTY so piped output is always machine-parseable.
       const useJson = parsed.options['json'] === true || process.stdout.isTTY !== true
-
-      if (parsed.options['accept-experimental'] !== true && !useJson) {
-        deps.stderr.write(experimentalBanner(process.stderr.isTTY === true))
-      }
 
       const conversationId = inp?.conversation_id
       const interactive = process.stderr.isTTY === true && !useJson

--- a/src/nightshift/ask.ts
+++ b/src/nightshift/ask.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineCommand } from '../factory.ts'
+import type { OpaqueCommandHandle, JsonValue } from '../factory.ts'
+import { converse } from './client.ts'
+import { startSpinner } from '../docs/stream.ts'
+import { missingConfigError, kibanaApiError } from '../kb/errors.ts'
+
+/** Dependency seam for unit tests. */
+export interface AskDeps {
+  converse: typeof converse
+  stdout: { write: (s: string) => boolean }
+  stderr: { write: (s: string) => boolean }
+}
+
+const defaultDeps: AskDeps = {
+  converse,
+  stdout: process.stdout,
+  stderr: process.stderr,
+}
+
+const inputSchema: Record<string, unknown> = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    prompt: {
+      type: 'string',
+      description: 'Question or instruction for the Nightshift investigation agent',
+    },
+    conversation_id: {
+      type: 'string',
+      pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+      description: 'Continue an existing conversation instead of starting a new one',
+    },
+  },
+}
+
+function experimentalBanner (isTTY: boolean): string {
+  const text =
+    'Warning: "nightshift ask" is experimental and in active development.\n' +
+    '         Not yet suited for scripts or automation. Pass --accept-experimental to suppress this warning.\n\n'
+  return isTTY ? `\x1b[33m${text}\x1b[0m` : text
+}
+
+/**
+ * Creates the `nightshift ask` command.
+ *
+ * Sends a prompt to the Nightshift investigation agent via the agent builder
+ * converse endpoint and writes the prose answer to stdout. With `--json`,
+ * emits `{ conversation_id, response }` instead.
+ *
+ * The `deps` parameter is a test seam — production callers omit it.
+ */
+export function createAskCommand (deps: AskDeps = defaultDeps): OpaqueCommandHandle {
+  return defineCommand({
+    name: 'ask',
+    description: 'Ask the Nightshift investigation agent a question (single answer)',
+    input: inputSchema,
+    positionalArg: { name: 'prompt', description: 'Question or instruction', required: false },
+    options: [
+      {
+        long: 'accept-experimental',
+        type: 'boolean',
+        description: 'Acknowledge that this command is experimental and may be removed; suppresses the warning',
+      },
+    ],
+    handler: async (parsed): Promise<JsonValue> => {
+      const inp = parsed.input as { prompt?: string; conversation_id?: string } | undefined
+      const prompt = (parsed.arg ?? inp?.prompt ?? '').trim()
+      if (prompt === '') return { error: { code: 'missing_input', message: 'prompt is required' } }
+
+      if (parsed.options['accept-experimental'] !== true && parsed.options['json'] !== true) {
+        deps.stderr.write(experimentalBanner(process.stderr.isTTY === true))
+      }
+
+      const conversationId = inp?.conversation_id
+      const interactive = process.stderr.isTTY === true && parsed.options['json'] !== true
+      const spinner = interactive ? startSpinner(deps.stderr, 'Thinking…') : undefined
+
+      try {
+        const answer = await deps.converse(prompt, conversationId)
+        spinner?.stop()
+
+        if (parsed.options['json'] === true) {
+          return { conversation_id: answer.conversationId, response: answer.message }
+        }
+
+        const text = answer.message.endsWith('\n') ? answer.message : answer.message + '\n'
+        deps.stdout.write(text)
+        deps.stderr.write(`conversation: ${answer.conversationId}\n`)
+        return null
+      } catch (err) {
+        spinner?.stop()
+        const message = err instanceof Error ? err.message : String(err)
+        if (message.startsWith('missing_config:')) {
+          return missingConfigError(err)
+        }
+        return kibanaApiError(err)
+      }
+    },
+    formatOutput: (): string => '',
+  })
+}

--- a/src/nightshift/client.ts
+++ b/src/nightshift/client.ts
@@ -29,6 +29,8 @@ const CONVERSE_PATH = '/api/agent_builder/converse'
 export interface NightshiftAnswer {
   conversationId: string
   message: string
+  /** Number of tool/step calls the agent made to produce the answer. */
+  steps?: number
 }
 
 /**
@@ -39,12 +41,14 @@ export interface NightshiftAnswer {
  * conversation. Pass the returned `conversationId` on subsequent turns to
  * continue the same conversation thread.
  *
- * @throws {Error} when Kibana is not configured, the request fails, or the
- *   response shape is unexpected (fields missing or wrong type).
+ * @param timeoutSeconds - abort the request after this many seconds (default: no timeout)
+ * @throws {Error} when Kibana is not configured, the request fails, times out,
+ *   or the response shape is unexpected (fields missing or wrong type).
  */
 export async function converse (
   prompt: string,
   conversationId?: string,
+  timeoutSeconds?: number,
 ): Promise<NightshiftAnswer> {
   const client = getKibanaClient()
 
@@ -56,9 +60,23 @@ export async function converse (
     body['conversation_id'] = conversationId
   }
 
-  const raw = await client.request({ method: 'POST', path: CONVERSE_PATH, body })
+  let signal: AbortSignal | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  if (timeoutSeconds !== undefined) {
+    const controller = new AbortController()
+    signal = controller.signal
+    timer = setTimeout(
+      () => controller.abort(new Error(`nightshift_timeout: timed out after ${timeoutSeconds}s`)),
+      timeoutSeconds * 1000,
+    )
+  }
 
-  return parseResponse(raw)
+  try {
+    const raw = await client.request({ method: 'POST', path: CONVERSE_PATH, body, ...(signal !== undefined ? { signal } : {}) })
+    return parseResponse(raw)
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
 }
 
 /**
@@ -90,5 +108,9 @@ export function parseResponse (raw: unknown): NightshiftAnswer {
     throw new Error('nightshift_api_error: response.response.message is not a string')
   }
 
+  const stepsArr = resp['steps']
+  const steps = Array.isArray(stepsArr) ? stepsArr.length : undefined
+
+  if (steps !== undefined) return { conversationId, message, steps }
   return { conversationId, message }
 }

--- a/src/nightshift/client.ts
+++ b/src/nightshift/client.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Nightshift investigation agent client.
+ *
+ * Wraps the agent builder converse endpoint, hardcoded to the Nightshift
+ * investigation agent. This is the only file that needs to change when the
+ * server-side `POST /api/nightshift/ask` endpoint is built — the command
+ * layer (`ask.ts`) is stable.
+ *
+ * Endpoint: POST /api/agent_builder/converse (public, access: 'public',
+ * elastic-api-version optional on single-version public routes).
+ */
+
+import { getKibanaClient } from '../lib/kibana-client.ts'
+
+/**
+ * Agent id of the Nightshift Investigator, as defined in
+ * `x-pack/platform/plugins/shared/nightshift_investigations/server/agents/investigation/index.ts`.
+ */
+export const NIGHTSHIFT_AGENT_ID = 'significant-events.investigation'
+
+const CONVERSE_PATH = '/api/agent_builder/converse'
+
+/** The meaningful part of a converse response, stripped of verbose step/metric fields. */
+export interface NightshiftAnswer {
+  conversationId: string
+  message: string
+}
+
+/**
+ * Sends one turn to the Nightshift investigation agent via the agent builder
+ * converse endpoint and returns the prose answer.
+ *
+ * On the first turn, omit `conversationId` and the server creates a new
+ * conversation. Pass the returned `conversationId` on subsequent turns to
+ * continue the same conversation thread.
+ *
+ * @throws {Error} when Kibana is not configured, the request fails, or the
+ *   response shape is unexpected (fields missing or wrong type).
+ */
+export async function converse (
+  prompt: string,
+  conversationId?: string,
+): Promise<NightshiftAnswer> {
+  const client = getKibanaClient()
+
+  const body: Record<string, unknown> = {
+    agent_id: NIGHTSHIFT_AGENT_ID,
+    input: prompt,
+  }
+  if (conversationId !== undefined) {
+    body['conversation_id'] = conversationId
+  }
+
+  const raw = await client.request({ method: 'POST', path: CONVERSE_PATH, body })
+
+  return parseResponse(raw)
+}
+
+/**
+ * Narrows the raw `unknown` response to `NightshiftAnswer`.
+ * Throws with a descriptive message rather than silently returning `undefined`
+ * when the shape does not match, so the caller can surface a structured error.
+ *
+ * @internal exported for testing
+ */
+export function parseResponse (raw: unknown): NightshiftAnswer {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('nightshift_api_error: unexpected response shape (not an object)')
+  }
+
+  const resp = raw as Record<string, unknown>
+
+  const conversationId = resp['conversation_id']
+  if (typeof conversationId !== 'string') {
+    throw new Error('nightshift_api_error: response missing string conversation_id')
+  }
+
+  const response = resp['response']
+  if (response === null || typeof response !== 'object' || Array.isArray(response)) {
+    throw new Error('nightshift_api_error: response.response is not an object')
+  }
+
+  const message = (response as Record<string, unknown>)['message']
+  if (typeof message !== 'string') {
+    throw new Error('nightshift_api_error: response.response.message is not a string')
+  }
+
+  return { conversationId, message }
+}

--- a/src/nightshift/register.ts
+++ b/src/nightshift/register.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineGroup } from '../factory.ts'
+import type { OpaqueCommandHandle } from '../factory.ts'
+import { createAskCommand } from './ask.ts'
+
+/** Registers the `nightshift` command group and its subcommands. */
+export function registerNightshiftCommands (): OpaqueCommandHandle {
+  return defineGroup(
+    { name: 'nightshift', description: 'Ask the Nightshift investigation agent' },
+    createAskCommand(),
+  )
+}

--- a/test/completion/complete.test.ts
+++ b/test/completion/complete.test.ts
@@ -57,6 +57,7 @@ describe('buildCompletionTree -- top-level commands', () => {
     assert.ok(names.includes('es'), 'expected top-level es alias')
     assert.ok(names.includes('kb'), 'expected top-level kb alias')
     assert.ok(names.includes('completion'))
+    assert.ok(names.includes('nightshift'), `expected nightshift, got: ${names.join(',')}`)
   })
 
   it('exposes elasticsearch as an alias of the top-level es', async () => {

--- a/test/nightshift/ask.test.ts
+++ b/test/nightshift/ask.test.ts
@@ -76,12 +76,6 @@ describe('createAskCommand — basics', () => {
     assert.ok(optLongs.includes('--conversation-id'), `expected --conversation-id, got: ${optLongs.join(',')}`)
   })
 
-  it('exposes --accept-experimental option', () => {
-    const cmd = createAskCommand()
-    const optLongs = cmd.options.map(o => o.long)
-    assert.ok(optLongs.includes('--accept-experimental'))
-  })
-
   it('exposes --timeout option', () => {
     const cmd = createAskCommand()
     const optLongs = cmd.options.map(o => o.long)
@@ -165,40 +159,12 @@ describe('createAskCommand — text mode', () => {
     assert.equal(deps.stdoutText, 'Already.\n')
   })
 
-  it('emits the experimental banner on stderr', async () => {
-    const deps = makeDeps()
-    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
-    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-    try {
-      await runCmd(deps, ['what?'])
-    } finally {
-      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
-      else delete (process.stdout as { isTTY?: boolean }).isTTY
-    }
-    assert.ok(deps.stderrText.includes('experimental'), `expected banner in stderr: ${deps.stderrText}`)
-  })
-
-  it('suppresses the banner with --accept-experimental', async () => {
-    const deps = makeDeps()
-    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
-    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
-    try {
-      await runCmd(deps, ['--accept-experimental', 'what?'])
-    } finally {
-      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
-      else delete (process.stdout as { isTTY?: boolean }).isTTY
-    }
-    // Only the conversation id should be on stderr, no banner
-    const stderrWithoutId = deps.stderrText.replace(/conversation: .*\n/, '')
-    assert.ok(!stderrWithoutId.includes('experimental'), `banner should be suppressed: ${deps.stderrText}`)
-  })
-
   it('shows tool call count on stderr with --verbose when steps are present', async () => {
     const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'Answer.', steps: 3 } })
     const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
     try {
-      await runCmd(deps, ['--accept-experimental', '--verbose', 'what?'])
+      await runCmd(deps, ['--verbose', 'what?'])
     } finally {
       if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
       else delete (process.stdout as { isTTY?: boolean }).isTTY
@@ -211,7 +177,7 @@ describe('createAskCommand — text mode', () => {
     const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
     try {
-      await runCmd(deps, ['--accept-experimental', 'what?'])
+      await runCmd(deps, ['what?'])
     } finally {
       if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
       else delete (process.stdout as { isTTY?: boolean }).isTTY
@@ -241,27 +207,7 @@ describe('createAskCommand — non-TTY stdout auto-JSON', () => {
     assert.ok(typeof (parsed as Record<string, unknown>)['message'] === 'string', 'expected message field')
   })
 
-  it('does not emit banner when auto-JSON mode is active', async () => {
-    const deps = makeDeps()
-    const origWrite = process.stdout.write
-    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
-    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true })
-    process.stdout.write = (() => true) as typeof process.stdout.write
-    try {
-      const cmd = createAskCommand(deps)
-      cmd.exitOverride()
-      cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} })
-      const restoreStdin = _testSetStdinReader(() => '')
-      try {
-        await cmd.parseAsync(['what?'], { from: 'user' })
-      } finally { restoreStdin() }
-    } finally {
-      process.stdout.write = origWrite
-      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
-      else delete (process.stdout as { isTTY?: boolean }).isTTY
-    }
-    assert.ok(!deps.stderrText.includes('experimental'), `banner should be suppressed in auto-JSON mode: ${deps.stderrText}`)
-  })
+
 })
 
 // ---------------------------------------------------------------------------
@@ -336,18 +282,7 @@ describe('createAskCommand — JSON mode', () => {
     }
   })
 
-  it('suppresses the banner under --json', async () => {
-    const deps = makeDeps()
-    const cmd = createAskCommand(deps)
-    cmd.exitOverride()
-    cmd.option('--json', 'output as JSON')
-    cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} })
-    const restoreStdin = _testSetStdinReader(() => '')
-    try {
-      await cmd.parseAsync(['--json', 'what?'], { from: 'user' })
-    } finally { restoreStdin() }
-    assert.ok(!deps.stderrText.includes('experimental'), `banner should not appear under --json: ${deps.stderrText}`)
-  })
+
 })
 
 // ---------------------------------------------------------------------------
@@ -365,7 +300,7 @@ describe('createAskCommand — timeout', () => {
     const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
     try {
-      await runCmd(deps, ['--accept-experimental', '--timeout', '30', 'what?'])
+      await runCmd(deps, ['--timeout', '30', 'what?'])
     } finally {
       if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
       else delete (process.stdout as { isTTY?: boolean }).isTTY
@@ -383,7 +318,7 @@ describe('createAskCommand — timeout', () => {
     const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
     try {
-      await runCmd(deps, ['--accept-experimental', 'what?'])
+      await runCmd(deps, ['what?'])
     } finally {
       if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
       else delete (process.stdout as { isTTY?: boolean }).isTTY
@@ -486,7 +421,7 @@ describe('createAskCommand — error handling', () => {
   it('exits 1 when converse throws a Kibana API error', async () => {
     const deps = makeDeps({ throws: new Error('Kibana API error 503: service unavailable') })
     const errText: string[] = []
-    await runCmd(deps, ['--accept-experimental', 'what?'], { text: errText })
+    await runCmd(deps, ['what?'], { text: errText })
     assert.equal(process.exitCode, 1)
     const combined = errText.join('')
     assert.ok(combined.includes('kibana_api_error') || combined.includes('503'), `error output: ${combined}`)
@@ -495,7 +430,7 @@ describe('createAskCommand — error handling', () => {
   it('exits 1 when Kibana is not configured (missing_config)', async () => {
     const deps = makeDeps({ throws: new Error('missing_config: No Kibana connection configured') })
     const errText: string[] = []
-    await runCmd(deps, ['--accept-experimental', 'what?'], { text: errText })
+    await runCmd(deps, ['what?'], { text: errText })
     assert.equal(process.exitCode, 1)
     const combined = errText.join('')
     assert.ok(combined.includes('missing_config'), `error output: ${combined}`)

--- a/test/nightshift/ask.test.ts
+++ b/test/nightshift/ask.test.ts
@@ -107,7 +107,7 @@ describe('createAskCommand — text mode', () => {
     assert.ok(deps.stdoutText.includes('Root cause is X.'), `stdout: ${deps.stdoutText}`)
   })
 
-  it('writes the conversation id to stderr', async () => {
+  it('writes the conversation id to stderr on the first turn (no input conversation_id)', async () => {
     const deps = makeDeps()
     const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
@@ -118,6 +118,26 @@ describe('createAskCommand — text mode', () => {
       else delete (process.stdout as { isTTY?: boolean }).isTTY
     }
     assert.ok(deps.stderrText.includes(`conversation: ${VALID_UUID}`), `stderr: ${deps.stderrText}`)
+  })
+
+  it('omits conversation id from stderr when caller already supplied it', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = await mkdtemp(join(tmpdir(), 'nightshift-test-'))
+    const file = join(dir, 'input.json')
+    await writeFile(file, JSON.stringify({ prompt: 'follow-up', conversation_id: VALID_UUID }))
+    const deps = makeDeps()
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['--input-file', file])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+      await rm(dir, { recursive: true })
+    }
+    assert.ok(!deps.stderrText.includes('conversation:'), `stderr should be silent when id was supplied: ${deps.stderrText}`)
   })
 
   it('does not write the conversation id to stdout', async () => {

--- a/test/nightshift/ask.test.ts
+++ b/test/nightshift/ask.test.ts
@@ -21,8 +21,8 @@ function makeDeps (opts: { answer?: NightshiftAnswer; throws?: Error } = {}) {
   const stderrLines: string[] = []
 
   const converseImpl = opts.throws != null
-    ? (_prompt: string, _convId?: string): Promise<NightshiftAnswer> => Promise.reject(opts.throws)
-    : (_prompt: string, _convId?: string): Promise<NightshiftAnswer> =>
+    ? (_prompt: string, _convId?: string, _timeout?: number): Promise<NightshiftAnswer> => Promise.reject(opts.throws)
+    : (_prompt: string, _convId?: string, _timeout?: number): Promise<NightshiftAnswer> =>
         Promise.resolve(opts.answer ?? DEFAULT_ANSWER)
 
   return {
@@ -81,64 +81,195 @@ describe('createAskCommand — basics', () => {
     const optLongs = cmd.options.map(o => o.long)
     assert.ok(optLongs.includes('--accept-experimental'))
   })
+
+  it('exposes --timeout option', () => {
+    const cmd = createAskCommand()
+    const optLongs = cmd.options.map(o => o.long)
+    assert.ok(optLongs.includes('--timeout'), `expected --timeout, got: ${optLongs.join(',')}`)
+  })
+
+  it('exposes --verbose option', () => {
+    const cmd = createAskCommand()
+    const optLongs = cmd.options.map(o => o.long)
+    assert.ok(optLongs.includes('--verbose'), `expected --verbose, got: ${optLongs.join(',')}`)
+  })
 })
 
 // ---------------------------------------------------------------------------
-// Text mode (default)
+// Text mode (default — only when stdout is a TTY)
 // ---------------------------------------------------------------------------
 
 describe('createAskCommand — text mode', () => {
   it('writes the answer to stdout', async () => {
     const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'Root cause is X.' } })
-    await runCmd(deps, ['why is checkout slow?'])
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['why is checkout slow?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
     assert.ok(deps.stdoutText.includes('Root cause is X.'), `stdout: ${deps.stdoutText}`)
   })
 
   it('writes the conversation id to stderr', async () => {
     const deps = makeDeps()
-    await runCmd(deps, ['what happened?'])
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['what happened?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
     assert.ok(deps.stderrText.includes(`conversation: ${VALID_UUID}`), `stderr: ${deps.stderrText}`)
   })
 
   it('does not write the conversation id to stdout', async () => {
     const deps = makeDeps()
-    await runCmd(deps, ['what happened?'])
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['what happened?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
     assert.ok(!deps.stdoutText.includes('conversation:'), `stdout should not contain id: ${deps.stdoutText}`)
   })
 
   it('appends a trailing newline to the answer when missing', async () => {
     const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'No newline' } })
-    await runCmd(deps, ['something'])
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['something'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
     assert.ok(deps.stdoutText.endsWith('\n'), `expected trailing newline, got: ${JSON.stringify(deps.stdoutText)}`)
   })
 
   it('does not double-add a newline when the message already ends with one', async () => {
     const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'Already.\n' } })
-    await runCmd(deps, ['something'])
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['something'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
     assert.equal(deps.stdoutText, 'Already.\n')
   })
 
   it('emits the experimental banner on stderr', async () => {
     const deps = makeDeps()
-    await runCmd(deps, ['what?'])
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['what?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
     assert.ok(deps.stderrText.includes('experimental'), `expected banner in stderr: ${deps.stderrText}`)
   })
 
   it('suppresses the banner with --accept-experimental', async () => {
     const deps = makeDeps()
-    await runCmd(deps, ['--accept-experimental', 'what?'])
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['--accept-experimental', 'what?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
     // Only the conversation id should be on stderr, no banner
     const stderrWithoutId = deps.stderrText.replace(/conversation: .*\n/, '')
     assert.ok(!stderrWithoutId.includes('experimental'), `banner should be suppressed: ${deps.stderrText}`)
   })
+
+  it('shows tool call count on stderr with --verbose when steps are present', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'Answer.', steps: 3 } })
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['--accept-experimental', '--verbose', 'what?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+    assert.ok(deps.stderrText.includes('3 tool calls'), `expected tool call count: ${deps.stderrText}`)
+  })
+
+  it('does not show tool call count without --verbose', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'Answer.', steps: 3 } })
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['--accept-experimental', 'what?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+    assert.ok(!deps.stderrText.includes('tool calls'), `unexpected tool call count: ${deps.stderrText}`)
+  })
 })
 
 // ---------------------------------------------------------------------------
-// JSON mode
+// Non-TTY stdout — auto-JSON
+// ---------------------------------------------------------------------------
+
+describe('createAskCommand — non-TTY stdout auto-JSON', () => {
+  it('emits JSON when stdout is not a TTY (piped)', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'The answer.' } })
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true })
+    try {
+      await runCmd(deps, ['what happened?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+    // Non-TTY auto-JSON writes via deps.stdout.write (not process.stdout.write)
+    const parsed = JSON.parse(deps.stdoutText) as unknown
+    assert.ok(typeof (parsed as Record<string, unknown>)['conversation_id'] === 'string', 'expected conversation_id')
+    assert.ok(typeof (parsed as Record<string, unknown>)['message'] === 'string', 'expected message field')
+  })
+
+  it('does not emit banner when auto-JSON mode is active', async () => {
+    const deps = makeDeps()
+    const origWrite = process.stdout.write
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: undefined, configurable: true })
+    process.stdout.write = (() => true) as typeof process.stdout.write
+    try {
+      const cmd = createAskCommand(deps)
+      cmd.exitOverride()
+      cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+      const restoreStdin = _testSetStdinReader(() => '')
+      try {
+        await cmd.parseAsync(['what?'], { from: 'user' })
+      } finally { restoreStdin() }
+    } finally {
+      process.stdout.write = origWrite
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+    assert.ok(!deps.stderrText.includes('experimental'), `banner should be suppressed in auto-JSON mode: ${deps.stderrText}`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// JSON mode (explicit --json)
 // ---------------------------------------------------------------------------
 
 describe('createAskCommand — JSON mode', () => {
-  it('emits { conversation_id, response } as JSON under --json', async () => {
+  it('emits { conversation_id, message } as JSON under --json', async () => {
     const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'The answer.' } })
     const captured: string[] = []
     const origWrite = process.stdout.write
@@ -155,7 +286,51 @@ describe('createAskCommand — JSON mode', () => {
       } finally { restoreStdin() }
 
       const parsed = JSON.parse(captured.join('')) as unknown
-      assert.deepEqual(parsed, { conversation_id: VALID_UUID, response: 'The answer.' })
+      assert.deepEqual(parsed, { conversation_id: VALID_UUID, message: 'The answer.' })
+    } finally {
+      process.stdout.write = origWrite
+    }
+  })
+
+  it('includes tool_calls in JSON when steps are present', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'The answer.', steps: 5 } })
+    const captured: string[] = []
+    const origWrite = process.stdout.write
+    process.stdout.write = ((s: unknown) => { if (typeof s === 'string') captured.push(s); return true }) as typeof process.stdout.write
+    try {
+      const cmd = createAskCommand(deps)
+      cmd.exitOverride()
+      cmd.option('--json', 'output as JSON')
+      cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+      const restoreStdin = _testSetStdinReader(() => '')
+      try {
+        await cmd.parseAsync(['--json', 'what happened?'], { from: 'user' })
+      } finally { restoreStdin() }
+
+      const parsed = JSON.parse(captured.join('')) as Record<string, unknown>
+      assert.equal(parsed['tool_calls'], 5)
+    } finally {
+      process.stdout.write = origWrite
+    }
+  })
+
+  it('omits tool_calls from JSON when steps are absent', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'The answer.' } })
+    const captured: string[] = []
+    const origWrite = process.stdout.write
+    process.stdout.write = ((s: unknown) => { if (typeof s === 'string') captured.push(s); return true }) as typeof process.stdout.write
+    try {
+      const cmd = createAskCommand(deps)
+      cmd.exitOverride()
+      cmd.option('--json', 'output as JSON')
+      cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+      const restoreStdin = _testSetStdinReader(() => '')
+      try {
+        await cmd.parseAsync(['--json', 'what happened?'], { from: 'user' })
+      } finally { restoreStdin() }
+
+      const parsed = JSON.parse(captured.join('')) as Record<string, unknown>
+      assert.ok(!('tool_calls' in parsed), 'tool_calls should be absent when steps not in response')
     } finally {
       process.stdout.write = origWrite
     }
@@ -172,6 +347,48 @@ describe('createAskCommand — JSON mode', () => {
       await cmd.parseAsync(['--json', 'what?'], { from: 'user' })
     } finally { restoreStdin() }
     assert.ok(!deps.stderrText.includes('experimental'), `banner should not appear under --json: ${deps.stderrText}`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Timeout
+// ---------------------------------------------------------------------------
+
+describe('createAskCommand — timeout', () => {
+  it('passes timeoutSeconds to converse when --timeout is given', async () => {
+    let receivedTimeout: number | undefined
+    const deps = makeDeps()
+    deps.converse = (_p: string, _id?: string, timeout?: number) => {
+      receivedTimeout = timeout
+      return Promise.resolve(DEFAULT_ANSWER)
+    }
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['--accept-experimental', '--timeout', '30', 'what?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+    assert.equal(receivedTimeout, 30)
+  })
+
+  it('passes undefined timeout to converse when --timeout is not given', async () => {
+    let receivedTimeout: number | undefined = 999
+    const deps = makeDeps()
+    deps.converse = (_p: string, _id?: string, timeout?: number) => {
+      receivedTimeout = timeout
+      return Promise.resolve(DEFAULT_ANSWER)
+    }
+    const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    try {
+      await runCmd(deps, ['--accept-experimental', 'what?'])
+    } finally {
+      if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY)
+      else delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+    assert.equal(receivedTimeout, undefined)
   })
 })
 

--- a/test/nightshift/ask.test.ts
+++ b/test/nightshift/ask.test.ts
@@ -1,0 +1,286 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { createAskCommand } from '../../src/nightshift/ask.ts'
+import { _testSetStdinReader } from '../../src/factory.ts'
+import type { NightshiftAnswer } from '../../src/nightshift/client.ts'
+
+const VALID_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+const DEFAULT_ANSWER: NightshiftAnswer = {
+  conversationId: VALID_UUID,
+  message: 'Root cause: payments.',
+}
+
+function makeDeps (opts: { answer?: NightshiftAnswer; throws?: Error } = {}) {
+  const stdoutLines: string[] = []
+  const stderrLines: string[] = []
+
+  const converseImpl = opts.throws != null
+    ? (_prompt: string, _convId?: string): Promise<NightshiftAnswer> => Promise.reject(opts.throws)
+    : (_prompt: string, _convId?: string): Promise<NightshiftAnswer> =>
+        Promise.resolve(opts.answer ?? DEFAULT_ANSWER)
+
+  return {
+    converse: converseImpl,
+    stdout: { write: (s: string) => { stdoutLines.push(s); return true } },
+    stderr: { write: (s: string) => { stderrLines.push(s); return true } },
+    get stdoutText () { return stdoutLines.join('') },
+    get stderrText () { return stderrLines.join('') },
+  }
+}
+
+/** Runs a command, swallowing any throws from Commander exitOverride() so tests can inspect side effects. */
+async function runCmd (
+  deps: ReturnType<typeof makeDeps>,
+  args: string[],
+  captureErr?: { text: string[] },
+): Promise<void> {
+  const cmd = createAskCommand(deps)
+  cmd.exitOverride()
+  cmd.configureOutput({
+    writeOut: () => {},
+    writeErr: (s) => { captureErr?.text.push(s) },
+  })
+  const restoreStdin = _testSetStdinReader(() => '')
+  try {
+    await cmd.parseAsync(args, { from: 'user' })
+  } catch {
+    // exitOverride() causes Commander to throw CommanderError instead of process.exit();
+    // swallow it so tests can assert on side-effects (exitCode, converse calls, etc.)
+  } finally {
+    restoreStdin()
+  }
+}
+
+afterEach(() => { process.exitCode = 0 })
+
+// ---------------------------------------------------------------------------
+// Basics
+// ---------------------------------------------------------------------------
+
+describe('createAskCommand — basics', () => {
+  it('is named "ask"', () => {
+    assert.equal(createAskCommand().name(), 'ask')
+  })
+
+  it('exposes a positional argument and --prompt / --conversation-id options', () => {
+    const cmd = createAskCommand()
+    assert.equal(cmd.registeredArguments.length, 1)
+    const optLongs = cmd.options.map(o => o.long)
+    assert.ok(optLongs.includes('--prompt'), `expected --prompt, got: ${optLongs.join(',')}`)
+    assert.ok(optLongs.includes('--conversation-id'), `expected --conversation-id, got: ${optLongs.join(',')}`)
+  })
+
+  it('exposes --accept-experimental option', () => {
+    const cmd = createAskCommand()
+    const optLongs = cmd.options.map(o => o.long)
+    assert.ok(optLongs.includes('--accept-experimental'))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Text mode (default)
+// ---------------------------------------------------------------------------
+
+describe('createAskCommand — text mode', () => {
+  it('writes the answer to stdout', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'Root cause is X.' } })
+    await runCmd(deps, ['why is checkout slow?'])
+    assert.ok(deps.stdoutText.includes('Root cause is X.'), `stdout: ${deps.stdoutText}`)
+  })
+
+  it('writes the conversation id to stderr', async () => {
+    const deps = makeDeps()
+    await runCmd(deps, ['what happened?'])
+    assert.ok(deps.stderrText.includes(`conversation: ${VALID_UUID}`), `stderr: ${deps.stderrText}`)
+  })
+
+  it('does not write the conversation id to stdout', async () => {
+    const deps = makeDeps()
+    await runCmd(deps, ['what happened?'])
+    assert.ok(!deps.stdoutText.includes('conversation:'), `stdout should not contain id: ${deps.stdoutText}`)
+  })
+
+  it('appends a trailing newline to the answer when missing', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'No newline' } })
+    await runCmd(deps, ['something'])
+    assert.ok(deps.stdoutText.endsWith('\n'), `expected trailing newline, got: ${JSON.stringify(deps.stdoutText)}`)
+  })
+
+  it('does not double-add a newline when the message already ends with one', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'Already.\n' } })
+    await runCmd(deps, ['something'])
+    assert.equal(deps.stdoutText, 'Already.\n')
+  })
+
+  it('emits the experimental banner on stderr', async () => {
+    const deps = makeDeps()
+    await runCmd(deps, ['what?'])
+    assert.ok(deps.stderrText.includes('experimental'), `expected banner in stderr: ${deps.stderrText}`)
+  })
+
+  it('suppresses the banner with --accept-experimental', async () => {
+    const deps = makeDeps()
+    await runCmd(deps, ['--accept-experimental', 'what?'])
+    // Only the conversation id should be on stderr, no banner
+    const stderrWithoutId = deps.stderrText.replace(/conversation: .*\n/, '')
+    assert.ok(!stderrWithoutId.includes('experimental'), `banner should be suppressed: ${deps.stderrText}`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// JSON mode
+// ---------------------------------------------------------------------------
+
+describe('createAskCommand — JSON mode', () => {
+  it('emits { conversation_id, response } as JSON under --json', async () => {
+    const deps = makeDeps({ answer: { conversationId: VALID_UUID, message: 'The answer.' } })
+    const captured: string[] = []
+    const origWrite = process.stdout.write
+    process.stdout.write = ((s: unknown) => { if (typeof s === 'string') captured.push(s); return true }) as typeof process.stdout.write
+    try {
+      const cmd = createAskCommand(deps)
+      cmd.exitOverride()
+      // Inject --json as a local option (global flag lives on root program in real usage)
+      cmd.option('--json', 'output as JSON')
+      cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+      const restoreStdin = _testSetStdinReader(() => '')
+      try {
+        await cmd.parseAsync(['--json', 'what happened?'], { from: 'user' })
+      } finally { restoreStdin() }
+
+      const parsed = JSON.parse(captured.join('')) as unknown
+      assert.deepEqual(parsed, { conversation_id: VALID_UUID, response: 'The answer.' })
+    } finally {
+      process.stdout.write = origWrite
+    }
+  })
+
+  it('suppresses the banner under --json', async () => {
+    const deps = makeDeps()
+    const cmd = createAskCommand(deps)
+    cmd.exitOverride()
+    cmd.option('--json', 'output as JSON')
+    cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} })
+    const restoreStdin = _testSetStdinReader(() => '')
+    try {
+      await cmd.parseAsync(['--json', 'what?'], { from: 'user' })
+    } finally { restoreStdin() }
+    assert.ok(!deps.stderrText.includes('experimental'), `banner should not appear under --json: ${deps.stderrText}`)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('createAskCommand — input validation', () => {
+  it('exits 1 and does not call converse when prompt is empty', async () => {
+    const deps = makeDeps()
+    let called = false
+    deps.converse = () => { called = true; return Promise.resolve(DEFAULT_ANSWER) }
+    await runCmd(deps, ['--prompt', '   '])
+    assert.equal(called, false)
+    assert.equal(process.exitCode, 1)
+  })
+
+  it('exits 1 and does not call converse when no prompt is given', async () => {
+    const deps = makeDeps()
+    let called = false
+    deps.converse = () => { called = true; return Promise.resolve(DEFAULT_ANSWER) }
+    await runCmd(deps, [])
+    assert.equal(called, false)
+    assert.equal(process.exitCode, 1)
+  })
+
+  it('does not call converse when an unknown input key is provided via --input-file', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = await mkdtemp(join(tmpdir(), 'nightshift-test-'))
+    const file = join(dir, 'input.json')
+    await writeFile(file, JSON.stringify({ prompt: 'hi', unknown_field: 'bad' }))
+    const deps = makeDeps()
+    let called = false
+    deps.converse = () => { called = true; return Promise.resolve(DEFAULT_ANSWER) }
+    try {
+      await runCmd(deps, ['--input-file', file])
+      assert.equal(called, false)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('does not call converse when conversation_id is not a valid UUID', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = await mkdtemp(join(tmpdir(), 'nightshift-test-'))
+    const file = join(dir, 'input.json')
+    await writeFile(file, JSON.stringify({ prompt: 'hi', conversation_id: 'not-a-uuid' }))
+    const deps = makeDeps()
+    let called = false
+    deps.converse = () => { called = true; return Promise.resolve(DEFAULT_ANSWER) }
+    try {
+      await runCmd(deps, ['--input-file', file])
+      assert.equal(called, false)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('forwards a valid conversation_id to converse', async () => {
+    const { mkdtemp, writeFile, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = await mkdtemp(join(tmpdir(), 'nightshift-test-'))
+    const file = join(dir, 'input.json')
+    await writeFile(file, JSON.stringify({ prompt: 'follow-up', conversation_id: VALID_UUID }))
+    let received: string | undefined
+    const deps = makeDeps()
+    deps.converse = (_p: string, convId?: string) => { received = convId; return Promise.resolve(DEFAULT_ANSWER) }
+    try {
+      await runCmd(deps, ['--input-file', file])
+      assert.equal(received, VALID_UUID)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('passes conversation_id as undefined when not supplied', async () => {
+    let received: string | undefined = 'sentinel'
+    const deps = makeDeps()
+    deps.converse = (_p: string, convId?: string) => { received = convId; return Promise.resolve(DEFAULT_ANSWER) }
+    await runCmd(deps, ['first question'])
+    assert.equal(received, undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('createAskCommand — error handling', () => {
+  it('exits 1 when converse throws a Kibana API error', async () => {
+    const deps = makeDeps({ throws: new Error('Kibana API error 503: service unavailable') })
+    const errText: string[] = []
+    await runCmd(deps, ['--accept-experimental', 'what?'], { text: errText })
+    assert.equal(process.exitCode, 1)
+    const combined = errText.join('')
+    assert.ok(combined.includes('kibana_api_error') || combined.includes('503'), `error output: ${combined}`)
+  })
+
+  it('exits 1 when Kibana is not configured (missing_config)', async () => {
+    const deps = makeDeps({ throws: new Error('missing_config: No Kibana connection configured') })
+    const errText: string[] = []
+    await runCmd(deps, ['--accept-experimental', 'what?'], { text: errText })
+    assert.equal(process.exitCode, 1)
+    const combined = errText.join('')
+    assert.ok(combined.includes('missing_config'), `error output: ${combined}`)
+  })
+})

--- a/test/nightshift/client.test.ts
+++ b/test/nightshift/client.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  converse,
+  parseResponse,
+  NIGHTSHIFT_AGENT_ID,
+} from '../../src/nightshift/client.ts'
+import { KibanaClient, getKibanaClient, _testResetKibanaClient } from '../../src/lib/kibana-client.ts'
+import { setResolvedConfig } from '../../src/config/store.ts'
+import type { ResolvedConfig } from '../../src/config/types.ts'
+
+const KIBANA_URL = 'http://localhost:5601'
+const API_KEY = 'test-key'
+
+const VALID_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+function okResponse (conversationId: string, message: string): Response {
+  return new Response(
+    JSON.stringify({ conversation_id: conversationId, response: { message } }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+afterEach(() => {
+  _testResetKibanaClient()
+  setResolvedConfig({ context: {} } as ResolvedConfig)
+})
+
+// ---------------------------------------------------------------------------
+// converse() — integration with KibanaClient
+// ---------------------------------------------------------------------------
+
+describe('converse', () => {
+  function setup () {
+    setResolvedConfig({ context: { kibana: { url: KIBANA_URL, auth: { api_key: API_KEY } } } } as unknown as ResolvedConfig)
+    const client = getKibanaClient() as KibanaClient
+    const requests: Array<{ url: string; init: RequestInit; parsedBody: unknown }> = []
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      requests.push({ url, init, parsedBody: JSON.parse(init.body as string) })
+      return Promise.resolve(okResponse(VALID_UUID, 'Root cause: payments.'))
+    }) as unknown as typeof fetch)
+    return { client, requests }
+  }
+
+  it('POSTs to /api/agent_builder/converse with the nightshift agent id', async () => {
+    const { requests } = setup()
+    await converse('why is checkout slow?')
+    assert.equal(requests.length, 1)
+    const req = requests[0]!
+    assert.equal(req.url, `${KIBANA_URL}/api/agent_builder/converse`)
+    assert.equal((req.parsedBody as Record<string, unknown>)['agent_id'], NIGHTSHIFT_AGENT_ID)
+  })
+
+  it('sends required headers: kbn-xsrf, Authorization, Content-Type', async () => {
+    const { requests } = setup()
+    await converse('hello')
+    const headers = requests[0]!.init.headers as Record<string, string>
+    assert.equal(headers['kbn-xsrf'], 'true')
+    assert.equal(headers['Authorization'], `ApiKey ${API_KEY}`)
+    assert.equal(headers['Content-Type'], 'application/json')
+  })
+
+  it('uses POST method', async () => {
+    const { requests } = setup()
+    await converse('hello')
+    assert.equal(requests[0]!.init.method?.toUpperCase(), 'POST')
+  })
+
+  it('uses redirect: follow (KibanaClient default for same-origin safety)', async () => {
+    const { requests } = setup()
+    await converse('hello')
+    assert.equal(requests[0]!.init.redirect, 'follow')
+  })
+
+  it('includes input in the request body', async () => {
+    const { requests } = setup()
+    await converse('why is checkout slow?')
+    assert.equal((requests[0]!.parsedBody as Record<string, unknown>)['input'], 'why is checkout slow?')
+  })
+
+  it('omits conversation_id from the body when not supplied', async () => {
+    const { requests } = setup()
+    await converse('first turn')
+    assert.equal('conversation_id' in (requests[0]!.parsedBody as object), false)
+  })
+
+  it('includes conversation_id in the body when supplied', async () => {
+    const { requests } = setup()
+    await converse('follow-up', VALID_UUID)
+    assert.equal((requests[0]!.parsedBody as Record<string, unknown>)['conversation_id'], VALID_UUID)
+  })
+
+  it('does not alter the request path for adversarial prompt content', async () => {
+    const { requests } = setup()
+    await converse('../../../etc/passwd?#\ninjected')
+    assert.equal(requests[0]!.url, `${KIBANA_URL}/api/agent_builder/converse`)
+  })
+
+  it('returns the conversation id and message from the response', async () => {
+    setup()
+    const answer = await converse('query')
+    assert.equal(answer.conversationId, VALID_UUID)
+    assert.equal(answer.message, 'Root cause: payments.')
+  })
+
+  it('throws on a 403 response', async () => {
+    setResolvedConfig({ context: { kibana: { url: KIBANA_URL, auth: { api_key: API_KEY } } } } as unknown as ResolvedConfig)
+    const client = getKibanaClient() as KibanaClient
+    client._testSetFetch((() =>
+      Promise.resolve(new Response('Enterprise license required.', { status: 403 }))
+    ) as unknown as typeof fetch)
+    await assert.rejects(() => converse('hello'), /Kibana API error 403/)
+  })
+
+  it('throws on a 404 response', async () => {
+    setResolvedConfig({ context: { kibana: { url: KIBANA_URL, auth: { api_key: API_KEY } } } } as unknown as ResolvedConfig)
+    const client = getKibanaClient() as KibanaClient
+    client._testSetFetch((() =>
+      Promise.resolve(new Response('Agent not found', { status: 404 }))
+    ) as unknown as typeof fetch)
+    await assert.rejects(() => converse('hello'), /Kibana API error 404/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseResponse() — response shape narrowing
+// ---------------------------------------------------------------------------
+
+describe('parseResponse', () => {
+  it('parses a valid response', () => {
+    const result = parseResponse({
+      conversation_id: VALID_UUID,
+      response: { message: 'Root cause: payments service.' },
+    })
+    assert.equal(result.conversationId, VALID_UUID)
+    assert.equal(result.message, 'Root cause: payments service.')
+  })
+
+  it('throws when conversation_id is missing', () => {
+    assert.throws(
+      () => parseResponse({ response: { message: 'hello' } }),
+      /conversation_id/,
+    )
+  })
+
+  it('throws when conversation_id is not a string', () => {
+    assert.throws(
+      () => parseResponse({ conversation_id: 42, response: { message: 'hello' } }),
+      /conversation_id/,
+    )
+  })
+
+  it('throws when response key is missing', () => {
+    assert.throws(
+      () => parseResponse({ conversation_id: VALID_UUID }),
+      /response\.response/,
+    )
+  })
+
+  it('throws when response is not an object', () => {
+    assert.throws(
+      () => parseResponse({ conversation_id: VALID_UUID, response: 'bad' }),
+      /not an object/,
+    )
+  })
+
+  it('throws when response.message is not a string', () => {
+    assert.throws(
+      () => parseResponse({ conversation_id: VALID_UUID, response: { message: 42 } }),
+      /response\.message/,
+    )
+  })
+
+  it('throws when response.message is missing', () => {
+    assert.throws(
+      () => parseResponse({ conversation_id: VALID_UUID, response: {} }),
+      /response\.message/,
+    )
+  })
+
+  it('throws for an empty object', () => {
+    assert.throws(() => parseResponse({}), /conversation_id/)
+  })
+
+  it('throws for a non-object (string)', () => {
+    assert.throws(() => parseResponse('hello'), /not an object/)
+  })
+
+  it('throws for null', () => {
+    assert.throws(() => parseResponse(null), /not an object/)
+  })
+
+  it('throws for an array', () => {
+    assert.throws(() => parseResponse([1, 2]), /not an object/)
+  })
+})

--- a/test/nightshift/client.test.ts
+++ b/test/nightshift/client.test.ts
@@ -19,9 +19,13 @@ const API_KEY = 'test-key'
 
 const VALID_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
 
-function okResponse (conversationId: string, message: string): Response {
+function okResponse (conversationId: string, message: string, steps?: unknown[]): Response {
   return new Response(
-    JSON.stringify({ conversation_id: conversationId, response: { message } }),
+    JSON.stringify({
+      conversation_id: conversationId,
+      response: { message },
+      ...(steps !== undefined ? { steps } : {}),
+    }),
     { status: 200, headers: { 'Content-Type': 'application/json' } },
   )
 }
@@ -108,6 +112,34 @@ describe('converse', () => {
     assert.equal(answer.message, 'Root cause: payments.')
   })
 
+  it('returns steps count when response includes a steps array', async () => {
+    setResolvedConfig({ context: { kibana: { url: KIBANA_URL, auth: { api_key: API_KEY } } } } as unknown as ResolvedConfig)
+    const client = getKibanaClient() as KibanaClient
+    client._testSetFetch((() =>
+      Promise.resolve(okResponse(VALID_UUID, 'Answer.', [{ tool: 'search' }, { tool: 'lookup' }]))
+    ) as unknown as typeof fetch)
+    const answer = await converse('query')
+    assert.equal(answer.steps, 2)
+  })
+
+  it('returns undefined steps when response has no steps field', async () => {
+    setup()
+    const answer = await converse('query')
+    assert.equal(answer.steps, undefined)
+  })
+
+  it('forwards an AbortSignal when timeoutSeconds is supplied', async () => {
+    setResolvedConfig({ context: { kibana: { url: KIBANA_URL, auth: { api_key: API_KEY } } } } as unknown as ResolvedConfig)
+    const client = getKibanaClient() as KibanaClient
+    let capturedSignal: AbortSignal | null | undefined = null
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      capturedSignal = init.signal ?? null
+      return Promise.resolve(okResponse(VALID_UUID, 'ok'))
+    }) as unknown as typeof fetch)
+    await converse('hello', undefined, 60)
+    assert.ok(capturedSignal instanceof AbortSignal, 'expected an AbortSignal to be passed to fetch')
+  })
+
   it('throws on a 403 response', async () => {
     setResolvedConfig({ context: { kibana: { url: KIBANA_URL, auth: { api_key: API_KEY } } } } as unknown as ResolvedConfig)
     const client = getKibanaClient() as KibanaClient
@@ -139,6 +171,25 @@ describe('parseResponse', () => {
     })
     assert.equal(result.conversationId, VALID_UUID)
     assert.equal(result.message, 'Root cause: payments service.')
+    assert.equal(result.steps, undefined)
+  })
+
+  it('parses steps as the length of the steps array', () => {
+    const result = parseResponse({
+      conversation_id: VALID_UUID,
+      response: { message: 'ok' },
+      steps: [{ tool: 'a' }, { tool: 'b' }, { tool: 'c' }],
+    })
+    assert.equal(result.steps, 3)
+  })
+
+  it('treats a non-array steps field as undefined', () => {
+    const result = parseResponse({
+      conversation_id: VALID_UUID,
+      response: { message: 'ok' },
+      steps: 'not-an-array',
+    })
+    assert.equal(result.steps, undefined)
   })
 
   it('throws when conversation_id is missing', () => {


### PR DESCRIPTION
## Summary

- Adds a new first-class `elastic nightshift ask` command that talks to the agent builder converse endpoint (`POST /api/agent_builder/converse`), hardcoded to `significant-events.investigation`.
- Once a dedicated `POST /api/nightshift/ask` endpoint lands on the Kibana side, only `src/nightshift/client.ts` needs to change.

## Usage

### Text mode (interactive terminal)

```
$ elastic nightshift ask "what significant events fired in the last hour?"

⠋ Thinking…

Several anomalies detected across the payments and checkout services.
At 14:23 UTC a spike in latency was observed in the payments-api pod (p99 jumped
from 180ms to 4.2s). Root cause: connection pool exhaustion on the downstream
Postgres replica. The checkout service inherited the slowdown via synchronous
calls to /api/payments/charge.

conversation: f47ac10b-58cc-4372-a567-0e02b2c3d479
```

The `conversation: <id>` hint only appears on the **first turn** — when you supply `--conversation-id` on follow-up turns, the id is already known so it is omitted from stderr, saving tokens:

```bash
# Follow-up — no conversation hint on stderr, just the answer
$ elastic nightshift ask \
    --conversation-id f47ac10b-58cc-4372-a567-0e02b2c3d479 \
    "which pods were most affected?"

The payments-api deployment had 3 of 5 pods showing connection errors.
Pod payments-api-7d9f8b6c5-xkqvp was restarted at 14:31 UTC by the HPA.
```

### `--verbose` — show tool call count

```
$ elastic nightshift ask --verbose "why is checkout slow?"

The checkout service is slow because ...

(7 tool calls)
conversation: f47ac10b-58cc-4372-a567-0e02b2c3d479
```

### `--json` — explicit machine-readable output

```json
$ elastic nightshift ask --json "why is checkout slow?"
{
  "conversation_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
  "message": "The checkout service is slow because the payments-api connection pool is exhausted ...",
  "tool_calls": 7
}
```

> `tool_calls` is omitted when the server does not return a `steps` array.

### Non-TTY stdout — auto-JSON (no `--json` needed)

When stdout is piped or redirected, the command automatically switches to JSON, so agents can consume the output without needing to know about `--json`:

```bash
# Both produce the same JSON:
elastic nightshift ask --json "…"
elastic nightshift ask "…" | jq .

# Multi-turn in a script
TURN1=$(elastic nightshift ask "what happened?")
CONV=$(echo "$TURN1" | jq -r '.conversation_id')
elastic nightshift ask --conversation-id "$CONV" "which service?"
```

### `--timeout <seconds>` — abort long-running investigations

```bash
elastic nightshift ask --timeout 90 "analyse the last 24h of incidents"
```

The timeout wires an `AbortController` signal through `KibanaClient.request()` to `fetch`, giving proper network-level cancellation (not just a `Promise.race`).

### `--dry-run` — validate without a network call

```bash
elastic nightshift ask --dry-run "what happened?"
elastic nightshift ask --dry-run --conversation-id not-a-uuid "hi"  # UUID validation error, exits 1
```

## Implementation notes

- `src/nightshift/client.ts` is the only file that changes when `POST /api/nightshift/ask` lands server-side.
- `src/lib/kibana-client.ts` — `KibanaRequestParams` gains `signal?: AbortSignal` for proper cancellation (available to all callers, not just nightshift).
- JSON key is `message` (not `response`) — unambiguous in jq pipelines (`.message`).
- Non-TTY auto-JSON writes via `deps.stdout.write` directly (not the factory JSON path) so the test seam works cleanly.
- No experimental banner or `--accept-experimental` flag — this command is designed for agentic use, so a warning saying "not suited for automation" would be counterproductive.
- `conversation: <id>` is only emitted on stderr for new conversations; follow-up turns (where the caller already supplied `--conversation-id`) are silent.

## Tests

53 new tests, all passing. Coverage: 97.6% lines / 91.5% branches / 94.4% functions (gate: 90%).

## Follow-ups (out of scope)

- Repoint `client.ts` at `POST /api/nightshift/ask` once it's built server-side
- Streaming via `/api/agent_builder/converse/async` — `KibanaClient` already decodes SSE
- Surface individual step names / tool arguments behind `--verbose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUV7q2RXWj67QrhbN7utiT