### PR TITLE
ci: add auto-approve workflow for Renovate automerge

### DIFF
--- a/.github/workflows/auto-approve-renovate-prs.yml
+++ b/.github/workflows/auto-approve-renovate-prs.yml
@@ -1,0 +1,28 @@
+name: Auto-Approve Renovate PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [auto_merge_enabled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.user.login == 'elastic-renovate-prod[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'renovate-auto-approve')
+    steps:
+      - name: Approve Renovate PR
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: "APPROVE"
+            })

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,14 @@
   "schedule": [
     "* 0-3 1 * *"
   ],
-  "prConcurrentLimit": 10
+  "prConcurrentLimit": 10,
+  "automergeStrategy": "squash",
+  "automergeType": "pr",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
+      "addLabels": ["renovate-auto-approve"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Adds auto-approve workflow gated on elastic-renovate-prod[bot] actor and renovate-auto-approve label, for hands-free PR-based automerge.

Updates renovate.json to:

- Add renovate-auto-approve label to patch/minor/pin/digest PRs
- Set automergeStrategy: squash and automergeType: pr

Prerequisites (must be enabled in repo settings):

- Settings > General > Pull Requests > Allow auto-merge
- Settings > Actions > General > Workflow permissions > Allow GitHub Actions to create and approve pull requests

Assisted-by: Claude Sonnet 4.5
